### PR TITLE
Force brlaser to use CMake minimum policy version 3.5 instead of 3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN echo -e "https://dl-cdn.alpinelinux.org/alpine/edge/testing\nhttps://dl-cdn.
 RUN apk add --no-cache git cmake && \
     git clone https://github.com/pdewacht/brlaser.git && \
     cd brlaser && \
-    cmake . && \
+    cmake . -DCMAKE_POLICY_VERSION_MINIMUM=3.5 && \
     make && \
     make install && \
     cd .. && \


### PR DESCRIPTION
I downloaded the project to add in a driver I needed for an older Canon inkjet printer, but when I went to build it the brlaser build step began complaining that it had removed compatibility for CMake under version 3.5 (using CMake 4.1.1-r0, the current version at this time)

```
 > [cups 3/8] RUN apk add --no-cache git cmake &&     git clone https://github.com/pdewacht/brlaser.git &&     cd brlaser &&     cmake . &&     make &&     make install &&     cd .. &&     rm -rf brlaser:
0.290 fetch https://dl-cdn.alpinelinux.org/alpine/v3.20/main/x86_64/APKINDEX.tar.gz
0.420 fetch https://dl-cdn.alpinelinux.org/alpine/v3.20/community/x86_64/APKINDEX.tar.gz
0.583 fetch https://dl-cdn.alpinelinux.org/alpine/edge/testing/x86_64/APKINDEX.tar.gz
0.784 fetch https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz
1.154 (1/13) Installing libarchive (3.8.1-r0)
1.171 (2/13) Installing rhash-libs (1.4.6-r0)
1.181 (3/13) Installing libuv (1.51.0-r0)
1.203 (4/13) Installing cmake (4.1.1-r0)
2.257 (5/13) Installing c-ares (1.34.5-r0)
2.268 (6/13) Installing nghttp2-libs (1.66.0-r0)
2.279 (7/13) Installing libpsl (0.21.5-r3)
2.287 (8/13) Installing libcurl (8.15.0-r1)
2.300 (9/13) Installing git (2.51.0-r0)
2.426 (10/13) Installing git-init-template (2.51.0-r0)
2.434 (11/13) Installing perl-error (0.17030-r0)
2.446 (12/13) Installing perl-git (2.51.0-r0)
2.455 (13/13) Installing git-perl (2.51.0-r0)
2.461 Executing busybox-1.36.1-r29.trigger
2.485 OK: 701 MiB in 204 packages
2.590 Cloning into 'brlaser'...
2.968 CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
2.968   Compatibility with CMake < 3.5 has been removed from CMake.
2.968
2.968   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
2.968   to tell CMake that the project requires at least <min> but has been updated
2.968   to work with policies introduced by <max> or earlier.
2.968
2.968   Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
2.968
2.968
2.968 -- Configuring incomplete, errors occurred!
------
failed to solve: process "/bin/sh -c apk add --no-cache git cmake &&     git clone https://github.com/pdewacht/brlaser.git &&     cd brlaser &&     cmake . &&     make &&     make install &&     cd .. &&     rm -rf brlaser" did not complete successfully: exit code: 1
```

Adding this build flag allows the compilation to complete with no further issues.