### PR TITLE
Add gcompat to Dockerfile dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN echo -e "https://dl-cdn.alpinelinux.org/alpine/edge/testing\nhttps://dl-cdn.
 	cups-client \
 	cups-filters \
 	cups-dev \
+	gcompat \
 	ghostscript \
 	hplip \
 	avahi \


### PR DESCRIPTION
Fixes ppds or filters that rely on dynamically linked files calling /lib64/ld-linux-x86-64.so.2 such as SATO ppds.

![image](https://github.com/user-attachments/assets/fe167b01-6885-4788-8f92-7160663f92a7)
rastertosbpl is a filter manually mapped to the container necessary for printers using SBPL (essentially all SATO printers).  