### PR TITLE
fix: wait for D-Bus and Avahi before starting CUPS

### DIFF
--- a/root/root/avahi-service.sh
+++ b/root/root/avahi-service.sh
@@ -75,8 +75,8 @@ wait_for_network() {
 start_dbus() {
     echo "Starting dbus-daemon..."
     mkdir -p /run/dbus
-    if [ -f /run/dbus/pid ]; then
-        rm -f /run/dbus/pid
+    if [ -f /run/dbus/dbus.pid ]; then
+        rm -f /run/dbus/dbus.pid
     fi
     dbus-daemon --system
     echo "dbus-daemon started"

--- a/root/root/run_cups.sh
+++ b/root/root/run_cups.sh
@@ -65,7 +65,14 @@ fi
 AVAHI_SERVICE_PID=$!
 
 # Wait a moment to ensure avahi-daemon has started and created its PID file
-sleep 2
+echo "Waiting for D-Bus and Avahi to be ready..."
+for i in $(seq 1 30); do
+    if [ -S /run/dbus/system_bus_socket ] && [ -f /var/run/avahi-daemon/pid ]; then
+        echo "D-Bus and Avahi ready after ${i}s"
+        break
+    fi
+    sleep 1
+done
 
 # Start CUPS and printer update
 /root/printer-update.sh &


### PR DESCRIPTION
CUPS was starting before D-Bus and Avahi were ready, causing it to log 'Unable to communicate with avahi-daemon: Daemon not running' and never register printers for AirPrint discovery.

Two fixes:
1. Replace hardcoded sleep 2 with a proper wait loop that checks for the D-Bus socket and Avahi pid file before starting CUPS.
2. Fix incorrect D-Bus pid filename in avahi-service.sh (was /run/dbus/pid, should be /run/dbus/dbus.pid), which caused stale pid files to not be cleaned up on restart.