### PR TITLE
Add TZ support and fix cups-pdf build (closes #50)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.20
 
 # Install the packages we need. Avahi will be included
-RUN echo -e "https://dl-cdn.alpinelinux.org/alpine/edge/testing\nhttps://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories &&\
+RUN echo -e "https://dl-cdn.alpinelinux.org/alpine/edge/testing\nhttps://dl-cdn.alpinelinux.org/alpine/edge/community\nhttps://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories &&\
 	apk add --update cups \
 	cups-libs \
 	cups-pdf \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN echo -e "https://dl-cdn.alpinelinux.org/alpine/edge/testing\nhttps://dl-cdn.
 	wget \
 	perl \
 	splix \
+	tzdata \
 	&& rm -rf /var/cache/apk/*
 
 # Build and install brlaser from source

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ CUPS registers shared printers directly with Avahi via D-Bus for mDNS/DNS-SD adv
 * `CUPSADMIN`: the CUPS admin user you want created - default is CUPSADMIN if unspecified
 * `CUPSPASSWORD`: the password for the CUPS admin user - default is the same value as `CUPSADMIN` if unspecified
 * `AVAHI_HOSTNAME`: the mDNS hostname Avahi will advertise - default is `cups-airprint`. Set this to a unique name if you have multiple instances, or if the default conflicts with your host's mDNS daemon (common on NAS devices like UGreen, Synology, etc.)
+* `TZ`: optional IANA timezone name (e.g. `Europe/Vienna`, `America/Los_Angeles`) used for log timestamps inside the container. Defaults to UTC if unset or invalid.
 
 ### Ports/Network:
 * Must be run on host network. This is required to support multicasting which is needed for Airprint.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,5 +10,6 @@ services:
     environment:
       CUPSADMIN: cups
       CUPSPASSWORD: cups
+      # TZ: Europe/Vienna  # optional, defaults to UTC
     volumes:
       - "./config:/config"

--- a/root/root/run_cups.sh
+++ b/root/root/run_cups.sh
@@ -2,6 +2,18 @@
 set -e
 set -x
 
+# Apply TZ if provided. Falls through to the image default (UTC) on missing
+# tzdata or invalid zone names so a typo can't keep the container from booting.
+if [ -n "$TZ" ]; then
+    if [ -f "/usr/share/zoneinfo/$TZ" ]; then
+        ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime
+        echo "$TZ" > /etc/timezone
+        echo "Timezone set to $TZ"
+    else
+        echo "Warning: TZ=$TZ is not a valid zone, leaving system as UTC"
+    fi
+fi
+
 # Is CUPSADMIN set? If not, set to default
 if [ -z "$CUPSADMIN" ]; then
     CUPSADMIN="cupsadmin"


### PR DESCRIPTION
Adds optional `TZ` support for container-local time and fixes a build break where Alpine moved `cups-pdf` out of the apk repos this image was pulling from.

## Changes

**Support `TZ` env var (closes #50)**
- Adds `tzdata` to the image
- `run_cups.sh` reads an optional `TZ` at startup, symlinks `/usr/share/zoneinfo/$TZ` to `/etc/localtime`, and writes `/etc/timezone`
- Invalid or unset `TZ` falls back to the image default (UTC) so a typo cannot block startup
- Documented in `README.md` and `docker-compose.yml`

**Add `edge/community` apk repo**
- Alpine moved `cups-pdf` out of `edge/main` and `edge/testing`; it now only ships in `edge/community`
- Adding that repo to `/etc/apk/repositories` fixes the `cups-pdf (no such package)` build failure that surfaced on aarch64 and amd64

## Verification

Built and ran `chuckcharlie/cups-avahi-airprint-test:latest` against the production `/config` and `/services` volumes:

- `TZ=America/Denver` → `Timezone set to America/Denver`, `date` reports MDT, `/etc/localtime` linked correctly
- `TZ=Not/A_Real_Zone` → warning logged, container continues in UTC
- `cups-pdf`, `tzdata`, `dbus`, `avahi` all present in image
- Existing printers loaded from `/config/printers.conf` after restart
- CUPS web UI responds HTTP 200 on `:631`
- D-Bus + Avahi readiness loop (from #49) fired and reported ready in 2s
