### PR TITLE
Add foo2zjs to support HP LaserJet 1020

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN echo -e "https://dl-cdn.alpinelinux.org/alpine/edge/testing\nhttps://dl-cdn.
 	perl \
 	splix \
 	tzdata \
-	&& rm -rf /var/cache/apk/*
+	jbigkit-dev 
 
 # Build and install brlaser from source
 RUN apk add --no-cache git cmake && \
@@ -45,6 +45,13 @@ RUN wget -O gutenprint-5.3.5.tar.xz https://sourceforge.net/projects/gimp-print/
     # Fix cups-genppdupdate script shebang
     sed -i '1s|.*|#!/usr/bin/perl|' /usr/sbin/cups-genppdupdate
 
+RUN git clone https://github.com/OpenPrinting/foo2zjs.git &&\
+    cd foo2zjs/ &&\
+    make -j$(nproc) && \
+    make install && \
+    cd .. && \
+	rm -rf foo2zjs /var/cache/apk/*
+	
 # This will use port 631
 EXPOSE 631
 


### PR DESCRIPTION
#46 
I shared an HP 1020 printer using p910nd on an ImmortalWrt device at x.x.x.209. Adding this printer on Windows worked and it could print normally. On a TrueNAS at x.x.x.2, I ran cups-avahi-airprint with Docker. After I added the HP 1020 on 209, it couldn't print. I compiled and installed foo2zjs inside the container, then switched the 1020's driver to foo2zjs, and it printed normally.